### PR TITLE
Update log4j to 2.17 to address CVE-2021-45105

### DIFF
--- a/Samples/4-read-local-save-adls/code-java/pom.xml
+++ b/Samples/4-read-local-save-adls/code-java/pom.xml
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.9.0</version>
+            <version>2.17.0</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION

https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45105